### PR TITLE
Styling tidy up

### DIFF
--- a/app/views/formAddNames.html
+++ b/app/views/formAddNames.html
@@ -3,36 +3,39 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Have you ever been known by any other names?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
+			{% include 'includes/error_summary.html' %}
+      {# include if this page has validation requirements #}
 
-
+      <h1 class="heading-medium">{{main_question}}</h1>
+      <p>This could be a different first or last name. For example if you got married, or changed your name by deed poll.</p>
 			<form action="formAddress" method="post" class="form">
+        <fieldset class="inline">
+          <legend class="visuallyhidden">{{main_question}}</legend>
 
 			    <div id="names-group" class="form-group">
-			    	<fieldset>
-			    		<legend class="heading-medium">Have you ever been known by any other names?</legend>
-			    		<p class="form-hint">This could be a different first or last name. For example if you got married, or changed your name by deed poll.</p>
+
 			    		<div id="names-group-error-message" class="form-error validation-message"></div>
 			    		<label class="block-label" for="name-radio-2">
 						    <input id="name-radio-2" type="radio" name="name-radio-group" value="No"
-						    	data-parsley-class-handler="#names-group" 
-          							data-parsley-errors-container="#names-group-error-message"
-          							data-parsley-required="true"
-    								data-parsley-required-message="Select 'no' if you haven't used any other names, or 'yes' if you have used other names"
+						    	data-parsley-class-handler="#names-group"
+          				data-parsley-errors-container="#names-group-error-message"
+          				data-parsley-required="true"
+    							data-parsley-required-message="Select 'no' if you haven't used any other names, or 'yes' if you have used other names"
 						    >
 						    No, I haven't used any other names
 					    </label>
 
 			    		<label class="block-label" data-target="name-change" for="name-radio-1">
 						    <input id="name-radio-1" type="radio" name="name-radio-group" value="Yes"
-						    	
+
 						    >
 						    Yes, I've used other names
 					    </label>
@@ -44,9 +47,9 @@
 
 			    	<!-- Expandable panel area -->
 			    	<div class="panel panel-border-narrow js-hidden" id="name-change">
-						
-						<p class="form-hint">Enter all your names in full - don't use initials.</p>
-						
+
+						<p>Enter all your names in full - don't use initials.</p>
+
 						<div id="add-name-container">
 							<div id="add-name-block">
 								<span class="heading-medium" id="new-name-title">Name </span>
@@ -55,7 +58,7 @@
 									<label class="form-label" for="given-names">First name(s)</label>
 									<div id="expand-given-name-group-error-message" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="other-given-names" type="text" id="given-names"
-										data-parsley-class-handler="#expand-given-name-group" 
+										data-parsley-class-handler="#expand-given-name-group"
 		          							data-parsley-errors-container="#expand-given-name-group-error-message"
 		          							data-parsley-required="true"
 		    								data-parsley-required-message="Enter your other first name(s)"
@@ -67,7 +70,7 @@
 									<label class="form-label" for="family-name">Last name(s)</label>
 									<div id="expand-family-name-group-error-message" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="other-family-name" type="text" id="family-name"
-										data-parsley-class-handler="#expand-family-name-group" 
+										data-parsley-class-handler="#expand-family-name-group"
 		          							data-parsley-errors-container="#expand-family-name-group-error-message"
 		          							data-parsley-required="true"
 		    								data-parsley-required-message="Enter your other last name(s)"
@@ -78,14 +81,15 @@
 								<!-- Date from -->
 								<div id="expand-date-from-group" class="form-group">
 									<fieldset>
-										
+
 										<div class="form-date">
 											<legend class="form-label">When did you start using this name?</legend>
+                      <p class="form-hint">For example, 03 1980</p>
 											<div id="expand-date-from-group-error-message" class="form-error validation-message"></div>
 											<div class="form-group form-group-month" id="expand-date-from-month-group">
 												<label for="name-from-month">Month</label>
 												<input disabled class="form-control" id="name-from-month" type="number" pattern="[0-9]*" maxlength="2" min="0" max="12" name="other-name-from-month"
-													data-parsley-class-handler="#expand-date-from-group" 
+													data-parsley-class-handler="#expand-date-from-group"
 		          									data-parsley-errors-container="#expand-date-from-group-error-message"
 		          									data-parsley-required="true"
 		    										data-parsley-required-message="Enter the month you started using this name"
@@ -94,18 +98,18 @@
 											<div class="form-group form-group-year" id="expand-date-from-year-group">
 												<label for="name-from-year">Year</label>
 												<input disabled class="form-control" id="name-from-year" type="number" pattern="[0-9]*" maxlength="4" min="1900" max="2016" name="other-name-from-year"
-													data-parsley-class-handler="#expand-date-from-group" 
+													data-parsley-class-handler="#expand-date-from-group"
 		          									data-parsley-errors-container="#expand-date-from-group-error-message"
 		          									data-parsley-required="true"
 		    										data-parsley-required-message="Enter the year you started using this name"
 												>
 											</div> <!-- Form group close-->
-											
+
 										</div> <!-- Form group close-->
 
 									</fieldset>
-									<p class="form-hint">For example, 03 1980</p>
-									
+
+
 								</div> <!-- Form group close-->
 
 								<br>
@@ -119,7 +123,6 @@
 						</div>
 
 					</div> <!-- Expandable panel area  Close -->
-			    </div> <!-- Form group close-->
 
 
 			    <!-- Continue button -->
@@ -146,7 +149,7 @@
 			<label class="form-label" for="given-names-">First name(s)</label>
 			<div id="expand-given-name-group-error-message-" class="form-error validation-message"></div>
 			<input disabled class="form-control" name="other-given-names-" type="text" id="given-names-"
-			data-parsley-class-handler="#expand-given-name-group-" 
+			data-parsley-class-handler="#expand-given-name-group-"
 			data-parsley-errors-container="#expand-given-name-group-error-message-"
 			data-parsley-required="true"
 			data-parsley-required-message="Enter your other first name(s) for name "
@@ -158,7 +161,7 @@
 			<label class="form-label" for="family-name-">Last name(s)</label>
 			<div id="expand-family-name-group-error-message-" class="form-error validation-message"></div>
 			<input disabled class="form-control" name="other-family-name-" type="text" id="family-name-"
-			data-parsley-class-handler="#expand-family-name-group-" 
+			data-parsley-class-handler="#expand-family-name-group-"
 			data-parsley-errors-container="#expand-family-name-group-error-message-"
 			data-parsley-required="true"
 			data-parsley-required-message="Enter your other last name(s) for name "
@@ -170,14 +173,14 @@
 		<div id="expand-date-from-group-" class="form-group">
 			<fieldset>
 				<legend class="form-label">When did you start using this name?</legend>
-				
+        	<p class="form-hint">For example, 03 1980</p>
 				<div class="form-date">
 
 				<div id="expand-date-from-group-error-message-" class="form-error validation-message"></div>
 					<div class="form-group form-group-month" id="expand-date-from-month-group-">
 						<label for="name-from-month-">Month</label>
 						<input disabled class="form-control" id="name-from-month-" type="number" pattern="[0-9]*" maxlength="2" min="0" max="12" name="other-name-from-month-"
-						data-parsley-class-handler="#expand-date-from-group-" 
+						data-parsley-class-handler="#expand-date-from-group-"
 						data-parsley-errors-container="#expand-date-from-group-error-message-"
 						data-parsley-required="true"
 						data-parsley-required-message="Enter the month you started using name "
@@ -186,7 +189,7 @@
 					<div class="form-group form-group-year" id="expand-date-from-year-group-">
 						<label for="name-from-year-">Year</label>
 						<input disabled class="form-control" id="name-from-year-" type="number" pattern="[0-9]*" maxlength="4" min="1900" max="2016" name="other-name-from-year-"
-						data-parsley-class-handler="#expand-date-from-group-" 
+						data-parsley-class-handler="#expand-date-from-group-"
 						data-parsley-errors-container="#expand-date-from-group-error-message-"
 						data-parsley-required="true"
 						data-parsley-required-message="Enter the year you started using name "
@@ -194,7 +197,7 @@
 					</div> <!-- Form group close-->
 				</div> <!-- Form group close-->
 			</fieldset>
-			<p class="form-hint">For example, 03 1980</p>
+
 		</div> <!-- Form group close-->
 
 
@@ -230,7 +233,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -282,15 +285,15 @@
 
 		  	changeId(children, counter);
 		  	document.getElementById('add-name-container').appendChild(obj);
-		  	
 
-		  	
+
+
 		  	$(document.getElementById('add-name-block-'+counter)).find('input,select,radio').prop('disabled', false);
-		  	
+
 		  	document.getElementById('new-name-title-'+counter).innerHTML +=String(counter);
 
 		  	document.getElementById('other-names-total').value = counter;
-		  	
+
 
 
 		  	counter+=1;
@@ -346,5 +349,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formAddress.html
+++ b/app/views/formAddress.html
@@ -3,49 +3,52 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Is this your current address?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
+			{% include 'includes/error_summary.html' %}
+      {# include if this page has validation requirements #}
 
 			<form action="formOtherAddresses" method="post" class="form">
 
-				
-				
-				
-				
+
+
+
+        <h1 class="heading-medium">{{main_question}}</h1>
 			  	<!-- Details correct -->
 				<div class="form-group" id="current-address-group">
 					<fieldset class="inline">
-						<legend class="heading-medium">Is this your current address?</legend>
+						<legend class="visuallyhidden">{{ main_question }}</legend>
 						<!-- Verified details -->
 						<div class="form-group">
-							<p class="form-hint">This is the address from your GOV.UK Verify account.</p>
-							<span>
+							<p>This is the address from your GOV.UK Verify account.</p>
+              <p>
+
 								1 Oxford Road<br>
 								Bristol<br>
 								South Gloucestershire<br>
 								United Kingdom<br>
 								LP1 12D
-							</span>
+							</p>
 						</div>
-						
+
 						<div id="current-address-group-error-message" class="form-error validation-message"></div>
 
 					    <label class="block-label" data-target="correct-address" for="correct-address-radio-1">
 							<input id="correct-address-radio-1" type="radio" name="radio-correct-address-group" value="Yes"
-									data-parsley-class-handler="#current-address-group" 
+									data-parsley-class-handler="#current-address-group"
           							data-parsley-errors-container="#current-address-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Select 'yes' if it is your current address, or 'no' if isn't"
 							>
 							Yes
 						</label>
-								
+
 						<label class="block-label" data-target="incorrect-address" for="correct-address-radio-2">
 							<input id="correct-address-radio-2" type="radio" name="radio-correct-address-group" value="No">
 							No
@@ -59,14 +62,14 @@
 						<div class="form-group" id="address-since-group" >
 							<fieldset>
 								<legend class="form-label">When did you move into this address?</legend>
-								
+                <p class="form-hint">For example, 03 1980</p>
 								<div class="form-date">
-									
+
 									<div id="address-since-group-error-message" class="form-error validation-message"></div>
 									<div class="form-group form-group-month">
 										<label for="correct-address-since-month">Month</label>
 										<input disabled class="form-control" name="correct-address-since-month" id="correct-address-since-month" type="number" maxlength="2" pattern="[0-9]*" min="0" max="12"
-											data-parsley-class-handler="#address-since-group" 
+											data-parsley-class-handler="#address-since-group"
           									data-parsley-errors-container="#address-since-group-error-message"
           									data-parsley-required="true"
     										data-parsley-required-message="Enter the month you moved into this address"
@@ -75,7 +78,7 @@
 									<div class="form-group form-group-year">
 										<label for="correct-address-since-year">Year</label>
 										<input disabled class="form-control" name="correct-address-since-year" id="correct-address-since-year" type="number" maxlength="4" pattern="[0-9]*" min="1900" max="2016"
-											data-parsley-class-handler="#address-since-group" 
+											data-parsley-class-handler="#address-since-group"
           									data-parsley-errors-container="#address-since-group-error-message"
           									data-parsley-required="true"
     										data-parsley-required-message="Enter the year you moved into this address"
@@ -84,8 +87,8 @@
 								</div>
 
 							</fieldset>
-							<p class="form-hint">For example, 03 1980</p>
-							
+
+
 						</div>
 					</div> <!-- Expandable panel area  Close CORRECT ADDRESS-->
 
@@ -105,7 +108,7 @@
 								<label class="form-label" for="postcode">Postcode</label>
 								<div id="postcode-block-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="postcode" type="text" id="postcode"
-									data-parsley-class-handler="#postcode-block" 
+									data-parsley-class-handler="#postcode-block"
           							data-parsley-errors-container="#postcode-block-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the address"
@@ -124,7 +127,7 @@
 						-->
 
 							<div class="form-group">
-								<label class="form-label">Postcode:</label> 
+								<label class="form-label">Postcode:</label>
 									<div id="current-entered-po" style="font-weight:bold;"></div>
 									<a href="#/" role="button" onClick="javascript:poLookup();">Change</a>
 
@@ -137,7 +140,7 @@
 									<li>
 										<label>
 											<input disabled type="radio" value="1 Oxford Road, London, United Kingdom" name="current-found-address"
-												data-parsley-class-handler="#current-po-finder-addresses" 
+												data-parsley-class-handler="#current-po-finder-addresses"
 			          							data-parsley-errors-container="#current-po-finder-error-message"
 			          							data-parsley-required="true"
 			    								data-parsley-required-message="Select the address"
@@ -185,7 +188,7 @@
 								<label class="form-label" for="new-address-line-1">Address line 1</label>
 								<div id="new-address-line-1-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="new-address-line-1" type="text" id="new-address-line-1"
-									data-parsley-class-handler="#new-address-line-1-group" 
+									data-parsley-class-handler="#new-address-line-1-group"
           							data-parsley-errors-container="#new-address-line-1-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the first address line"
@@ -199,7 +202,7 @@
 								<label class="form-label" for="new-address-town-city">Town/City</label>
 								<div id="new-town-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="new-address-town-city" type="text" id="new-address-town-city"
-									data-parsley-class-handler="#new-town-group" 
+									data-parsley-class-handler="#new-town-group"
           							data-parsley-errors-container="#new-town-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the town or city"
@@ -213,7 +216,7 @@
 								<label class="form-label" for="new-address-country">Country</label>
 								<div id="new-country-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="new-address-country" type="text" id="new-address-country"
-									data-parsley-class-handler="#new-country-group" 
+									data-parsley-class-handler="#new-country-group"
           							data-parsley-errors-container="#new-country-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the country"
@@ -223,7 +226,7 @@
 								<label class="form-label" for="new-address-postcode">Postcode</label>
 								<div id="new-postcode-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="new-address-postcode" type="text" id="new-address-postcode"
-									data-parsley-class-handler="#new-postcode-group" 
+									data-parsley-class-handler="#new-postcode-group"
           							data-parsley-errors-container="#new-postcode-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the postcode"
@@ -242,14 +245,14 @@
 						<div class="form-group" id="new-address-since-group">
 							<fieldset>
 								<legend class="form-label">When did you move into this address?</legend>
-								
+<p class="form-hint">For example, 03 1980</p>
 								<div class="form-date">
-									
+
 									<div id="new-address-since-group-error-message" class="form-error validation-message"></div>
 									<div class="form-group form-group-month">
 										<label for="incorrect-address-since-month">Month</label>
 										<input disabled class="form-control" id="incorrect-address-since-month" name="incorrect-address-since-month"type="number" pattern="[0-9]*" maxlength="2" min="0" max="12"
-											data-parsley-class-handler="#new-address-since-group" 
+											data-parsley-class-handler="#new-address-since-group"
           									data-parsley-errors-container="#new-address-since-group-error-message"
           									data-parsley-required="true"
     										data-parsley-required-message="Enter the month you moved into this address"
@@ -258,7 +261,7 @@
 									<div class="form-group form-group-year">
 										<label for="incorrect-address-since-year">Year</label>
 										<input disabled class="form-control" id="incorrect-address-since-year" name="incorrect-address-since-year" type="number" pattern="[0-9]*" maxlength="4" min="1900" max="2016"
-											data-parsley-class-handler="#new-address-since-group" 
+											data-parsley-class-handler="#new-address-since-group"
           									data-parsley-errors-container="#new-address-since-group-error-message"
           									data-parsley-required="true"
     										data-parsley-required-message="Enter the year you moved into this address"
@@ -266,8 +269,8 @@
 									</div>
 								</div>
 							</fieldset>
-							<p class="form-hint">For example, 03 1980</p>
-							
+
+
 						</div> <!-- Form group close-->
 					</div> <!-- Expandable panel area  Close INCORRECT ADDRESS -->
 
@@ -305,7 +308,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -344,7 +347,7 @@
 			// else disable those fields
 			if ($(this).val() == "Yes") {
 				// remove disabled prop
-				
+
 				correctAddressPanel.find('input,select,radio').prop('disabled',false);
 				newAddressPanel.find('input,select,radio').prop('disabled',true);
 				}
@@ -364,7 +367,7 @@
 					addressPanel.find('input,select,radio').prop('disabled',true);
 				}
 
-				
+
 			}
 		});
 
@@ -420,10 +423,8 @@
 			var po2 = po.slice((po.length-3),(po.length));
 			document.getElementById('current-entered-po').innerHTML += (po1 + ' ' + po2);
 		}
-							
+
 	}
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formComplete.html
+++ b/app/views/formComplete.html
@@ -7,6 +7,7 @@
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
@@ -20,7 +21,7 @@
 
 	      	<p>We have sent you a confirmation email with your application reference number.</p>
 
-	      	<h2 class="heading-medium">What happens next</h2>
+	      	<h2 class="heading-medium">What happens next?</h2>
 
 			<p>Your application will be processed by the Disclosure and Barring Service (DBS) and your certificate will be sent to you in the post.</p>
 			<p>It usually takes about 14 days to process your application.</p>
@@ -38,5 +39,3 @@
 </main>
 
 {% endblock %}
-
-

--- a/app/views/formConvictions.html
+++ b/app/views/formConvictions.html
@@ -3,33 +3,33 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Do you have any unspent convictions, cautions, reprimands or final warnings?" %}
 {% block content %}
 
 <main id="content" role="main">
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}		
-			
+			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
+      <h1 class="heading-medium">{{main_question}}</h1>
+      <p>You don't need to tell us about motoring fines or penalty points unless they were court imposed.</p>
 			<form action="formSendAddress" method="post" class="form">
-
 			    <div id="convictions-group" class="form-group">
 			    	<fieldset class="inline">
-			    		<legend class="heading-medium">Do you have any unspent convictions, cautions, reprimands or final warnings?</legend>
-			    		<p class="form-hint">You don't need to tell us about motoring fines or penalty points unless they were court imposed.</p>
+			    		<legend class="visuallyhidden">{{main_question}}</legend>
+
 			    		<div id="convictions-group-error-message" class="form-error validation-message"></div>
 
 			    		<!-- Yes/No Radio -->
 			    		<label class="block-label" for="radio-convictions-1">
 						    <input id="radio-convictions-1" type="radio" name="radio-convictions-group" value="Yes"
-						    	data-parsley-class-handler="#convictions-group" 
+						    	data-parsley-class-handler="#convictions-group"
           							data-parsley-errors-container="#convictions-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Confirm if you have other convictions"  >
 						    Yes
 					    </label>
-						
+
 					    <label class="block-label" for="radio-convictions-2">
 						    <input id="radio-convictions-2" type="radio" name="radio-convictions-group" value="No">
 						    No
@@ -74,7 +74,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -106,5 +106,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formDeclaration.html
+++ b/app/views/formDeclaration.html
@@ -7,16 +7,17 @@
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
 			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
-			
-			
+
+
 			<form action="https://payments:team@payment-prototype.herokuapp.com/dbs-choose-payment" method="post" class="form">
 
 			    <div class="form-group">
-			    	<h3 class="heading-medium">By continuing with your application you confirm that:</h3>
+			    	<h1 class="heading-medium">By continuing with your application you confirm that:</h1>
 			    	<ul class="list-bullet">
 			    		<li>the information you've given is true</li>
 			    		<li>you agree to the <a href="#">terms and conditions</a> and <a href="#">privacy policy</a></li>
@@ -41,7 +42,7 @@
 			    	<div id="check-declaration-group-error-message" class="form-error validation-message"></div>
 			    	<label class="block-label" for="check-declaration">
 						<input id="check-declaration" type="checkbox" name="check-declaration-group" value="Agree"
-							data-parsley-class-handler="#check-declaration-group" 
+							data-parsley-class-handler="#check-declaration-group"
           							data-parsley-errors-container="#check-declaration-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Tick the box to confirm you agree with the declaration">
@@ -83,7 +84,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -115,5 +116,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formEmail.html
+++ b/app/views/formEmail.html
@@ -3,29 +3,29 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "What is your email address?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
 			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
-
+      <h1 class="heading-medium">{{ main_question }}</h1>
+      <p>This will only be used to contact you about your application.</p>
 			<form action="formSummary" method="post" class="form">
-
-				
 			  	<!-- Email address -->
 			    <div id="email-entry-form-group" class="form-group">
-			      	<legend class="heading-medium" for="email-address">What is your email address?</legend>
-			      	<p class="form-hint">This will only be used to contact you about your application.</p>
+			      	<legend class="visuallyhidden" for="email-address">{{ main_question }}</legend>
+              <label class="form-label" for="confirm-email-address">Email address</label>
 			      	<div id="email-entry-form-group-error-message" class="form-error validation-message"></div>
 			      	<input type="text" class="form-control" name="email-address" id="email-address"
-			      		data-parsley-class-handler="#email-entry-form-group" 
+			      		data-parsley-class-handler="#email-entry-form-group"
           							data-parsley-errors-container="#email-entry-form-group-error-message"
           							data-parsley-required="true"
-    								data-parsley-required-message="Enter your email address" 
-    								data-parsley-type="email" 
+    								data-parsley-required-message="Enter your email address"
+    								data-parsley-type="email"
     								data-parsley-type-message="Enter a valid email address" >
 			    </div> <!-- Form group close-->
 
@@ -34,13 +34,13 @@
 			      	<label class="form-label" for="confirm-email-address">Confirm your email address</label>
 			      	<div id="email-confirm-form-group-error-message" class="form-error validation-message"></div>
 			      	<input type="text" class="form-control" id="confirm-email-address"
-			      		data-parsley-class-handler="#email-confirm-form-group" 
+			      		data-parsley-class-handler="#email-confirm-form-group"
           							data-parsley-errors-container="#email-confirm-form-group-error-message"
           							data-parsley-required="true"
-    								data-parsley-required-message="Confirm your email address" 
+    								data-parsley-required-message="Confirm your email address"
     								data-parsley-equalto="#email-address"
     								data-parsley-equalto-message="Your email addresses need to be the same"
-    								data-parsley-type="email" 
+    								data-parsley-type="email"
     								data-parsley-type-message="Enter a valid email address"  >
 			    </div> <!-- Form group close-->
 
@@ -78,7 +78,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -110,5 +110,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formFirstPage.html
+++ b/app/views/formFirstPage.html
@@ -3,44 +3,48 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Is this your correct name and date of birth?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
 			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
 
-			<form action="formGender" method="post" class="form">
-				<div id="verify-group" class="form-group">
-
-
-					
 
 
 
-					<fieldset class="inline">
-			    		<legend class="heading-medium">Is this your correct name and date of birth?</legend>
-			    		<p class="form-hint">These are your personal details from your GOV.UK Verify account.</p>
 
-			    		<span class="text-secondary">Name<br></span>
+
+
+
+
+			    		<h1 class="heading-medium">{{main_question}}</h1>
+			    		<p>These are your personal details from your GOV.UK Verify account.</p>
+              <form action="formGender" method="post" class="form">
+        				<div id="verify-group" class="form-group">
+              <fieldset class="inline">
+                <legend class="visuallyhidden">{{main_question}}</legend>
+			    		<span class="bold-small">Name<br></span>
 						<span>John Scott Smith<br></span>
-						<span class="text-secondary">Date of birth<br></span>
+            <br/>
+						<span class="bold-small">Date of birth<br></span>
 						<span>01/01/1960<br></span><br>
 
 			    		<div id="verify-form-group-error-message" class="form-error validation-message"></div>
 
 			    		<label class="block-label" for="radio-verify-1">
 						    <input id="radio-verify-1" type="radio" name="radio-verify-group" value="Yes"
-						    	data-parsley-class-handler="#verify-group" 
+						    	data-parsley-class-handler="#verify-group"
           							data-parsley-errors-container="#verify-form-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Select 'yes' if your name and date of birth are correct"
 						    >
 						    Yes
 					    </label>
-						
+
 					    <label class="block-label" for="radio-verify-2">
 						    <input id="radio-verify-2" type="radio" name="radio-verify-group" value="No">
 						    No
@@ -88,7 +92,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -119,5 +123,3 @@
 
 </script>
 {% endblock %}
-
-

--- a/app/views/formGender.html
+++ b/app/views/formGender.html
@@ -3,28 +3,31 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "What is your sex?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
+			{% include 'includes/error_summary.html' %}
+      {# include if this page has validation requirements #}
 
-			<form action="formPlaceBirth" method="post" class="form">
 
+      <h1 class="heading-medium">{{main_question}}</h1>
 
 			  	<!-- Gender -->
+        <form action="formPlaceBirth" method="post" class="form">
 				<div id="radio-gender-group-form-group" class="form-group">
 					<fieldset>
-						<legend class="heading-medium">What is your sex?</legend>
-						
+						<legend class="visuallyhidden">{{main_question}}</legend>
+
 						<div id="radio-gender-group-error-message" class="form-error validation-message"></div>
 
 						<label class="block-label" for="gender-radio-1">
-							<input id="gender-radio-1" type="radio" name="radio-gender-group" value="Female" 
-								data-parsley-class-handler="#radio-gender-group-form-group" 
+							<input id="gender-radio-1" type="radio" name="radio-gender-group" value="Female"
+								data-parsley-class-handler="#radio-gender-group-form-group"
           							data-parsley-errors-container="#radio-gender-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Select your sex" >
@@ -70,7 +73,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -101,5 +104,3 @@
 
 </script>
 {% endblock %}
-
-

--- a/app/views/formIdentity.html
+++ b/app/views/formIdentity.html
@@ -3,35 +3,37 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Do you have a National Insurance number?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
+			{% include 'includes/error_summary.html' %}
+      {# include if this page has validation requirements #}
 
-			
+<h1 class="heading-medium">{{main_question}}</h1>
 
 			<form action="formIdentityDriving" method="post" class="form">
 
 				<!-- National Insurance -->
 			    <div id="ni-form-group" class="form-group">
 			    	<fieldset class="inline">
-			    		<legend class="heading-medium">Do you have a National Insurance number?</legend>
+			    		<legend class="visuallyhidden">{{main_question}}</legend>
 			    		<!--<p class="form-hint">If you can provide this information your application will be processed quicker.</p>-->
 			    		<div id="ni-form-group-error-message" class="form-error validation-message"></div>
 			    		<label class="block-label" data-target="ni-number" for="radio-ni-1">
 						    <input id="radio-ni-1" type="radio" name="radio-ni-group" value="Yes"
-						    	data-parsley-class-handler="#ni-form-group" 
+						    	data-parsley-class-handler="#ni-form-group"
           							data-parsley-errors-container="#ni-form-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Select 'yes' if you have a National Insurance number"
 						    >
 						    Yes
 					    </label>
-						
+
 					    <label class="block-label" for="radio-ni-2">
 						    <input id="radio-ni-2" type="radio" name="radio-ni-group" value="No">
 						    No
@@ -46,7 +48,7 @@
 							<p class="form-hint">For example, QQ 12 34 56 C.</p>
 							<div id="ni-expand-form-group-error-message" class="form-error validation-message"></div>
 							<input disabled class="form-control" name="ni-number-input" type="text" id="ni-number-input"
-								data-parsley-class-handler="#ni-expand-form-group" 
+								data-parsley-class-handler="#ni-expand-form-group"
           							data-parsley-errors-container="#ni-expand-form-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter your National Insurance number"
@@ -65,16 +67,16 @@
 
 				    <div id="helpBlockText" class="panel panel-border-narrow js-hidden" >
 				    	<p>You can find your National Insurance number on your payslip, P60, or letters about tax, pensions, and benefits.</p>
-				    	
+
 
 
 					</div> <!-- END HELP BLOCK -->
-			    
+
 				</div>
 
 
 
-			    
+
 			    <!-- Continue button -->
 			    <div class="form-group">
 			    	<input type="submit" class="button" value="Save and continue">
@@ -108,7 +110,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -168,5 +170,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formIdentityDriving.html
+++ b/app/views/formIdentityDriving.html
@@ -3,35 +3,35 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Do you have a current UK driving licence?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
-			
+			{% include 'includes/error_summary.html' %}
+      {# include if this page has validation requirements #}
 
+      <h1 class="heading-medium">{{main_question}}</h1>
 			<form action="formIdentityPassport" method="post" class="form">
-
-
 			    <!-- Driving licence -->
 				<div id="driving-form-group" class="form-group">
 			    	<fieldset class="inline">
-			    		<legend class="heading-medium">Do you have a current UK driving licence?</legend>
+			    		<legend class="visuallyhidden">{{main_question}}</legend>
 			    		<!--<p class="form-hint">If you can provide this information your application will be processed quicker.</p>-->
 			    		<div id="driving-form-group-error-message" class="form-error validation-message"></div>
 			    		<label class="block-label" data-target="driving-licence" for="radio-driving-licence-1">
 						    <input id="radio-driving-licence-1" type="radio" name="radio-driving-licence-group" value="Yes"
-						    	data-parsley-class-handler="#driving-form-group" 
+						    	data-parsley-class-handler="#driving-form-group"
           							data-parsley-errors-container="#driving-form-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Select 'yes' if you have a current UK driving licence"
 						    >
 						    Yes
 					    </label>
-						
+
 					    <label class="block-label" for="radio-driving-licence-2">
 						    <input id="radio-driving-licence-2" type="radio" name="radio-driving-licence-group" value="No">
 						    No
@@ -46,17 +46,17 @@
 							<p class="form-hint">For example, MORGA657054SM9IJ.</p>
 							<div id="driving-expand-form-group-error-message" class="form-error validation-message"></div>
 							<input disabled class="form-control" name="driving-licence-number-input" type="text" id="driving-licence-number-input"
-								data-parsley-class-handler="#driving-expand-form-group" 
+								data-parsley-class-handler="#driving-expand-form-group"
           							data-parsley-errors-container="#driving-expand-form-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter your UK driving licence number"
 							>
 						</div> <!-- Form group close-->
-						
+
 					</div> <!-- Expandable panel area  Close -->
 			    </div> <!-- Form group close-->
 
-			    
+
 			    <!-- Continue button -->
 			    <div class="form-group">
 			    	<input type="submit" class="button" value="Save and continue">
@@ -90,7 +90,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -118,7 +118,7 @@
 	    return true;
 	  });
 
-	
+
 
 	  $("input[name=radio-driving-licence-group]").on('click', function() {
 	  	if($(this).val() == "Yes") {
@@ -133,10 +133,8 @@
 
 
 
-	
+
 
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formIdentityPassport.html
+++ b/app/views/formIdentityPassport.html
@@ -3,34 +3,35 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Do you have a current UK passport?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
 			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
-			
 
+      <h1 class="heading-medium">{{main_question}}</h1>
 			<form action="formConvictions" method="post" class="form">
 
 			    <!-- Passport -->
 				<div id="passport-form-group" class="form-group">
 			    	<fieldset class="inline">
-			    		<legend class="heading-medium">Do you have a current UK passport?</legend>
+			    		<legend class="visuallyhidden">{{main_question}}</legend>
 			    		<!--<p class="form-hint">If you can provide this information your application will be processed quicker.</p>-->
 			    		<div id="passport-form-group-error-message" class="form-error validation-message"></div>
 			    		<label class="block-label" data-target="passport-number" for="radio-passport-1">
 						    <input id="radio-passport-1" type="radio" name="radio-passport-group" value="Yes"
-						    	data-parsley-class-handler="#passport-form-group" 
+						    	data-parsley-class-handler="#passport-form-group"
           							data-parsley-errors-container="#passport-form-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Select 'yes' if you have a current UK passport"
 						    >
 						    Yes
 					    </label>
-						
+
 					    <label class="block-label" for="radio-passport-2">
 						    <input id="radio-passport-2" type="radio" name="radio-passport-group" value="No">
 						    No
@@ -44,7 +45,7 @@
 							<label class="form-label" for="passport-number-input">Passport number</label>
 							<div id="passport-number-expand-form-group-error-message" class="form-error validation-message"></div>
 							<input disabled class="form-control" name="passport-number-input" type="text" id="passport-number-input"
-								data-parsley-class-handler="#passport-number-expand-form-group" 
+								data-parsley-class-handler="#passport-number-expand-form-group"
           							data-parsley-errors-container="#passport-number-expand-form-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter your UK passport number"
@@ -90,7 +91,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -135,5 +136,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formOtherAddresses.html
+++ b/app/views/formOtherAddresses.html
@@ -3,24 +3,26 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Have you lived at any other addresses in the past 5 years?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
-			
+			{% include 'includes/error_summary.html' %}
+      {# include if this page has validation requirements #}
+      <h1 class="heading-medium">{{main_question}}</h1>
+      <p>Include temporary addresses, for example student accommodation or if you work away from home every week.</p>
+
+
 			<form action="formIdentity" method="post" class="form">
-
-
-				
 			    <div class="form-group" id="yes-no-addresses">
 			    	<div id="addressCheck">
 					    <div id="addressHistoryCheck-error-message" class="form-error validation-message"></div>
 					    <input disabled id="addressHistoryCheck" class="js-hidden"
-					    	data-parsley-class-handler="#addressCheck" 
+					    	data-parsley-class-handler="#addressCheck"
 							data-parsley-errors-container="#addressHistoryCheck-error-message"
 							data-parsley-required="true"
 							data-parsley-required-message="You need to enter a full 5 year address history"
@@ -29,7 +31,7 @@
 					<div id="gapsCheck">
 					    <div id="gapsCheck-error-message" class="form-error validation-message"></div>
 					    <input disabled id="addressGapCheck" class="js-hidden"
-					    	data-parsley-class-handler="#gapsCheck" 
+					    	data-parsley-class-handler="#gapsCheck"
 							data-parsley-errors-container="#gapsCheck-error-message"
 							data-parsley-required="true"
 							data-parsley-required-message="There are gaps in your address history"
@@ -39,12 +41,12 @@
 
 
 					<fieldset class="inline">
-			    		<legend class="heading-medium">Have you lived at any other addresses in the past 5 years?</legend>
-			    		<p class="form-hint">Include temporary addresses, for example student accommodation or if you work away from home every week.</p>
+			    		<legend class="visuallyhidden">{{main_question}}</legend>
+
 			    		<div id="addresses-group-error-message" class="form-error validation-message"></div>
 			    		<label class="block-label" data-target="yes-other-addresses-block" for="addresses-radio-1">
 						    <input id="addresses-radio-1" type="radio" name="addresses-radio-group" value="Yes"
-						    	data-parsley-class-handler="#yes-no-addresses" 
+						    	data-parsley-class-handler="#yes-no-addresses"
           							data-parsley-errors-container="#addresses-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Confirm if you have lived at other addresses"
@@ -65,11 +67,11 @@
 
 
 
-					
+
 
 						<!-- Store number of addresses the user has entered -->
 						<input class="js-hidden" id="other-addresses-total" name="other-addresses-total" value="1">
-						
+
 
 						<!-- ADD ADDRESS Hidden Panel -->
 
@@ -85,7 +87,7 @@
 									<label class="form-label" for="postcode-">Postcode</label>
 									<div id="postcode-block-error-message-" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="postcode-" type="text" id="postcode-"
-										data-parsley-class-handler="#postcode-block-" 
+										data-parsley-class-handler="#postcode-block-"
 	          							data-parsley-errors-container="#postcode-block-error-message-"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the postcode for address "
@@ -102,7 +104,7 @@
 							-->
 
 								<div class="form-group">
-									<label class="form-label">Postcode:</label> 
+									<label class="form-label">Postcode:</label>
 										<div id="entered-po-" style="font-weight:bold;"></div>
 										<a href="#/" id="change-" role="button" onClick="javascript:poLookup($(this).attr('id'));">Change</a>
 
@@ -115,7 +117,7 @@
 										<li>
 											<label>
 												<input disabled type="radio" value="1 Oxford Road, London, United Kingdom" name="po-other-address-"
-													data-parsley-class-handler="#po-finder-addresses-" 
+													data-parsley-class-handler="#po-finder-addresses-"
 				          							data-parsley-errors-container="#po-finder-error-message-"
 				          							data-parsley-required="true"
 				    								data-parsley-required-message="Select the address for address "
@@ -162,7 +164,7 @@
 									<label class="form-label" for="address-line-1-">Address line 1</label>
 									<div id="other-add-line-1-error-message-" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-line-1-" type="text" id="address-line-1-"
-										data-parsley-class-handler="#other-add-line-1-" 
+										data-parsley-class-handler="#other-add-line-1-"
 	          							data-parsley-errors-container="#other-add-line-1-error-message-"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the first line for address "
@@ -176,7 +178,7 @@
 									<label class="form-label" for="address-town-city-">Town/City</label>
 									<div id="other-add-city-error-message-" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-town-city-" type="text" id="address-town-city-"
-										data-parsley-class-handler="#other-add-city-" 
+										data-parsley-class-handler="#other-add-city-"
 	          							data-parsley-errors-container="#other-add-city-error-message-"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the city for address "
@@ -190,7 +192,7 @@
 									<label class="form-label" for="address-country-">Country</label>
 									<div id="other-add-country-error-message-" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-country-" type="text" id="address-country-"
-										data-parsley-class-handler="#other-add-country-" 
+										data-parsley-class-handler="#other-add-country-"
 	          							data-parsley-errors-container="#other-add-country-error-message-"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the country for address "
@@ -200,7 +202,7 @@
 									<label class="form-label" for="address-postcode-">Postcode</label>
 									<div id="other-add-postcode-error-message-" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-postcode-" type="text" id="address-postcode-"
-										data-parsley-class-handler="#other-add-postcode-" 
+										data-parsley-class-handler="#other-add-postcode-"
 	          							data-parsley-errors-container="#other-add-postcode-error-message-"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the postcode for address "
@@ -223,7 +225,7 @@
 
 								    	<label class="block-label" data-target="current-address-" for="current-address-radio-1-">
 											<input disabled id="current-address-radio-1-" type="radio" name="radio-current-address-group-" value="Yes"
-												data-parsley-class-handler="#current-radio-block-" 
+												data-parsley-class-handler="#current-radio-block-"
 			          							data-parsley-errors-container="#current-radio-block-error-message-"
 			          							data-parsley-required="true"
 			    								data-parsley-required-message="Is this a current address for address "
@@ -231,7 +233,7 @@
 											>
 										Yes
 										</label>
-											
+
 										<label class="block-label" data-target="not-current-address-" for="current-address-radio-2-">
 											<input disabled id="current-address-radio-2-" type="radio" name="radio-current-address-group-" value="No"
 												onClick="javascript:flipDisable($(this).attr('id'));"
@@ -248,14 +250,14 @@
 									<div class="form-group" id="cur-ad-since-group-">
 										<fieldset>
 											<legend class="form-label">When did you move into this address?</legend>
-											
+
 											<div class="form-date">
-												
+
 												<div id="cur-ad-since-group-error-message-" class="form-error validation-message"></div>
 												<div class="form-group form-group-month">
 													<label for="cur-address-since-month-">Month</label>
 													<input disabled class="form-control" id="cur-address-since-month-" type="number" name="cur-address-since-month-" pattern="[0-9]*" min="0" max="12"
-														data-parsley-class-handler="#cur-ad-since-group-" 
+														data-parsley-class-handler="#cur-ad-since-group-"
 					          							data-parsley-errors-container="#cur-ad-since-group-error-message-"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since month for address "
@@ -264,7 +266,7 @@
 												<div class="form-group form-group-year">
 													<label for="cur-address-since-year-">Year</label>
 													<input disabled class="form-control" id="cur-address-since-year-" type="number" name="cur-address-since-year-" pattern="[0-9]*" min="1900" max="2016"
-														data-parsley-class-handler="#cur-ad-since-group-" 
+														data-parsley-class-handler="#cur-ad-since-group-"
 					          							data-parsley-errors-container="#cur-ad-since-group-error-message-"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since year for address "
@@ -273,7 +275,7 @@
 											</div>
 										</fieldset>
 										<p class="form-hint">For example, 03 1980</p>
-										
+
 									</div> <!-- Form group close-->
 								</div> <!-- Expandable panel area  Close CURRENT ADDRESS -->
 
@@ -282,14 +284,14 @@
 									<div class="form-group" id="nc-ad-since-block-">
 										<fieldset>
 											<legend class="form-label">When did you move into this address?</legend>
-											
+
 											<div class="form-date">
-												
+
 												<div id="nc-ad-since-block-error-message-" class="form-error validation-message"></div>
 												<div class="form-group form-group-month">
 													<label for="nc-address-since-month-">Month</label>
 													<input disabled class="form-control" id="nc-address-since-month-" type="number" name="nc-address-since-month-" pattern="[0-9]*" min="0" max="12"
-														data-parsley-class-handler="#nc-ad-since-block-" 
+														data-parsley-class-handler="#nc-ad-since-block-"
 					          							data-parsley-errors-container="#nc-ad-since-block-error-message-"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since month for address "
@@ -298,7 +300,7 @@
 												<div class="form-group form-group-year">
 													<label for="nc-address-since-year-">Year</label>
 													<input disabled class="form-control" id="nc-address-since-year-" type="number" name="nc-address-since-year-" pattern="[0-9]*" min="1900" max="2016"
-														data-parsley-class-handler="#nc-ad-since-block-" 
+														data-parsley-class-handler="#nc-ad-since-block-"
 					          							data-parsley-errors-container="#nc-ad-since-block-error-message-"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since year for address "
@@ -307,20 +309,20 @@
 											</div>
 										</fieldset>
 										<p class="form-hint">For example, 03 1980</p>
-										
+
 									</div> <!-- Form group close-->
 
 									<div class="form-group" id="nc-ad-to-block-">
 										<fieldset>
 											<legend class="form-label">When did you move out of this address?</legend>
-											
+
 											<div class="form-date">
-												
+
 												<div id="nc-ad-to-block-error-message-" class="form-error validation-message"></div>
 												<div class="form-group form-group-month">
 													<label for="nc-address-to-month-">Month</label>
 													<input disabled class="form-control" id="nc-address-to-month-" type="number" name="nc-address-to-month-" pattern="[0-9]*" min="0" max="12"
-														data-parsley-class-handler="#nc-ad-to-block-" 
+														data-parsley-class-handler="#nc-ad-to-block-"
 					          							data-parsley-errors-container="#nc-ad-to-block-error-message-"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter to month for address "
@@ -329,7 +331,7 @@
 												<div class="form-group form-group-year">
 													<label for="nc-address-to-year-">Year</label>
 													<input disabled class="form-control" id="nc-address-to-year-" type="number" name="nc-address-to-year-" pattern="[0-9]*" min="1900" max="2016"
-														data-parsley-class-handler="#nc-ad-to-block-" 
+														data-parsley-class-handler="#nc-ad-to-block-"
 					          							data-parsley-errors-container="#nc-ad-to-block-error-message-"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter to year for address "
@@ -338,22 +340,22 @@
 											</div>
 										</fieldset>
 										<p class="form-hint">For example, 03 1980</p>
-										
+
 									</div> <!-- Form group close-->
 								</div> <!-- Expandable panel area  Close NOT CURRENT ADDRESS -->
 							</div> <!-- Form group close-->
 				    	</div> <!-- Expandable panel area  Close ADD ADDRESS -->
-				    	
+
 				    <!-- IF YES, DISPLAY THIS BLOCK -->
 					<div id="yes-other-addresses-block" class="js-hidden">
 
 				    	<div id="all-other-addresses-section">
-				    		
+
 
 				    	<div class="panel panel-border-narrow" id="add-other-address-1">
 
 				    		<span class="heading-medium" id="other-address-title-1">Address 1</span>
-				    		
+
 
 				    		<!-- Postcode finder block -->
 				    		<div class="form-group" id="postcode-block-1">
@@ -362,7 +364,7 @@
 									<label class="form-label" for="postcode-1">Postcode</label>
 									<div id="postcode-block-error-message-1" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="postcode-1" type="text" id="postcode-1"
-										data-parsley-class-handler="#postcode-block-1" 
+										data-parsley-class-handler="#postcode-block-1"
 	          							data-parsley-errors-container="#postcode-block-error-message-1"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the postcode for address 1"
@@ -379,7 +381,7 @@
 							-->
 
 								<div class="form-group">
-									<label class="form-label">Postcode:</label> 
+									<label class="form-label">Postcode:</label>
 										<div id="entered-po-1" style="font-weight:bold;"></div>
 										<a href="#/" id="change-1" role="button" onClick="javascript:poLookup($(this).attr('id'));">Change</a>
 
@@ -392,7 +394,7 @@
 										<li>
 											<label>
 												<input disabled type="radio" value="1 Oxford Road, London, United Kingdom" name="po-other-address-1"
-													data-parsley-class-handler="#po-finder-addresses-1" 
+													data-parsley-class-handler="#po-finder-addresses-1"
 				          							data-parsley-errors-container="#po-finder-error-message-1"
 				          							data-parsley-required="true"
 				    								data-parsley-required-message="Select the address for address 1"
@@ -439,7 +441,7 @@
 									<label class="form-label" for="address-line-1-1">Address line 1</label>
 									<div id="other-add-line-1-error-message-1" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-line-1-1" type="text" id="address-line-1-1"
-										data-parsley-class-handler="#other-add-line-1-1" 
+										data-parsley-class-handler="#other-add-line-1-1"
 	          							data-parsley-errors-container="#other-add-line-1-error-message-1"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the first line for address 1"
@@ -453,7 +455,7 @@
 									<label class="form-label" for="address-town-city-1">Town/City</label>
 									<div id="other-add-city-error-message-1" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-town-city-1" type="text" id="address-town-city-1"
-										data-parsley-class-handler="#other-add-city-1" 
+										data-parsley-class-handler="#other-add-city-1"
 	          							data-parsley-errors-container="#other-add-city-error-message-1"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the city for address 1"
@@ -467,7 +469,7 @@
 									<label class="form-label" for="address-country-1">Country</label>
 									<div id="other-add-country-error-message-1" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-country-1" type="text" id="address-country-1"
-										data-parsley-class-handler="#other-add-country-1" 
+										data-parsley-class-handler="#other-add-country-1"
 	          							data-parsley-errors-container="#other-add-country-error-message-1"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the country for address 1"
@@ -477,7 +479,7 @@
 									<label class="form-label" for="address-postcode-1">Postcode</label>
 									<div id="other-add-postcode-error-message-1" class="form-error validation-message"></div>
 									<input disabled class="form-control" name="address-postcode-1" type="text" id="address-postcode-1"
-										data-parsley-class-handler="#other-add-postcode-1" 
+										data-parsley-class-handler="#other-add-postcode-1"
 	          							data-parsley-errors-container="#other-add-postcode-error-message-1"
 	          							data-parsley-required="true"
 	    								data-parsley-required-message="Enter the postcode for address 1"
@@ -500,7 +502,7 @@
 
 								    	<label class="block-label" data-target="current-address-1" for="current-address-radio-1-1">
 											<input disabled id="current-address-radio-1-1" type="radio" name="radio-current-address-group-1" value="Yes"
-												data-parsley-class-handler="#current-radio-block-1" 
+												data-parsley-class-handler="#current-radio-block-1"
 			          							data-parsley-errors-container="#current-radio-block-error-message-1"
 			          							data-parsley-required="true"
 			    								data-parsley-required-message="Is this a current address for address 1"
@@ -508,7 +510,7 @@
 											>
 										Yes
 										</label>
-											
+
 										<label class="block-label" data-target="not-current-address-1" for="current-address-radio-2-1">
 											<input disabled id="current-address-radio-2-1" type="radio" name="radio-current-address-group-1" value="No"
 												onClick="javascript:flipDisable($(this).attr('id'));"
@@ -525,14 +527,14 @@
 									<div class="form-group" id="cur-ad-since-group-1">
 										<fieldset>
 											<legend class="form-label">When did you move into this address?</legend>
-											
+
 											<div class="form-date">
-												
+
 												<div id="cur-ad-since-group-error-message-1" class="form-error validation-message"></div>
 												<div class="form-group form-group-month">
 													<label for="cur-address-since-month-1">Month</label>
 													<input disabled class="form-control" id="cur-address-since-month-1" type="number" name="cur-address-since-month-1" pattern="[0-9]*" min="0" max="12"
-														data-parsley-class-handler="#cur-ad-since-group-1" 
+														data-parsley-class-handler="#cur-ad-since-group-1"
 					          							data-parsley-errors-container="#cur-ad-since-group-error-message-1"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since month for address 1"
@@ -541,7 +543,7 @@
 												<div class="form-group form-group-year">
 													<label for="cur-address-since-year-1">Year</label>
 													<input disabled class="form-control" id="cur-address-since-year-1" type="number" name="cur-address-since-year-1" pattern="[0-9]*" min="1900" max="2016"
-														data-parsley-class-handler="#cur-ad-since-group-1" 
+														data-parsley-class-handler="#cur-ad-since-group-1"
 					          							data-parsley-errors-container="#cur-ad-since-group-error-message-1"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since year for address 1"
@@ -550,7 +552,7 @@
 											</div>
 										</fieldset>
 										<p class="form-hint">For example, 03 1980</p>
-										
+
 									</div> <!-- Form group close-->
 								</div> <!-- Expandable panel area  Close CURRENT ADDRESS -->
 
@@ -559,14 +561,14 @@
 									<div class="form-group" id="nc-ad-since-block-1">
 										<fieldset>
 											<legend class="form-label">When did you move into this address?</legend>
-											
+
 											<div class="form-date">
-												
+
 												<div id="nc-ad-since-block-error-message-1" class="form-error validation-message"></div>
 												<div class="form-group form-group-month">
 													<label for="nc-address-since-month-1">Month</label>
 													<input disabled class="form-control" id="nc-address-since-month-1" type="number" name="nc-address-since-month-1" pattern="[0-9]*" min="0" max="12"
-														data-parsley-class-handler="#nc-ad-since-block-1" 
+														data-parsley-class-handler="#nc-ad-since-block-1"
 					          							data-parsley-errors-container="#nc-ad-since-block-error-message-1"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since month for address 1"
@@ -575,7 +577,7 @@
 												<div class="form-group form-group-year">
 													<label for="nc-address-since-year-1">Year</label>
 													<input disabled class="form-control" id="nc-address-since-year-1" type="number" name="nc-address-since-year-1" pattern="[0-9]*" min="1900" max="2016"
-														data-parsley-class-handler="#nc-ad-since-block-1" 
+														data-parsley-class-handler="#nc-ad-since-block-1"
 					          							data-parsley-errors-container="#nc-ad-since-block-error-message-1"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter since year for address 1"
@@ -584,20 +586,20 @@
 											</div>
 										</fieldset>
 										<p class="form-hint">For example, 03 1980</p>
-										
+
 									</div> <!-- Form group close-->
 
 									<div class="form-group" id="nc-ad-to-block-1">
 										<fieldset>
 											<legend class="form-label">When did you move out of this address?</legend>
-											
+
 											<div class="form-date">
-												
+
 												<div id="nc-ad-to-block-error-message-1" class="form-error validation-message"></div>
 												<div class="form-group form-group-month">
 													<label for="nc-address-to-month-1">Month</label>
 													<input disabled class="form-control" id="nc-address-to-month-1" type="number" name="nc-address-to-month-1" pattern="[0-9]*" min="0" max="12"
-														data-parsley-class-handler="#nc-ad-to-block-1" 
+														data-parsley-class-handler="#nc-ad-to-block-1"
 					          							data-parsley-errors-container="#nc-ad-to-block-error-message-1"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter to month for address 1"
@@ -606,7 +608,7 @@
 												<div class="form-group form-group-year">
 													<label for="nc-address-to-year-1">Year</label>
 													<input disabled class="form-control" id="nc-address-to-year-1" type="number" name="nc-address-to-year-1" pattern="[0-9]*" min="1900" max="2016"
-														data-parsley-class-handler="#nc-ad-to-block-1" 
+														data-parsley-class-handler="#nc-ad-to-block-1"
 					          							data-parsley-errors-container="#nc-ad-to-block-error-message-1"
 					          							data-parsley-required="true"
 					    								data-parsley-required-message="Enter to year for address 1"
@@ -615,7 +617,7 @@
 											</div>
 										</fieldset>
 										<p class="form-hint">For example, 03 1980</p>
-										
+
 									</div> <!-- Form group close-->
 								</div> <!-- Expandable panel area  Close NOT CURRENT ADDRESS -->
 							</div> <!-- Form group close-->
@@ -638,7 +640,7 @@
 						        //Set code to run when the link is clicked
 						        // by assigning a function to "onclick"
 						        a.onclick = function() {
-						            
+
 
 						        	var obj = document.getElementById('add-other-address-').cloneNode(true),
 			  						    children = obj.childNodes
@@ -649,7 +651,7 @@
 			  						document.getElementById('other-addresses-total').value = counter;
 			  						$('#mylink').html('Add another address');
 
-			 
+
 
 			  						document.getElementById('all-other-addresses-section').appendChild(obj);
 
@@ -666,7 +668,7 @@
 			  						counter+=1;
 
 
-			  						//change id recursively  
+			  						//change id recursively
 									function changeId(nodes, n){
 										for (var i=0;i<nodes.length;i=i+1){
 									    	if (nodes[i].childNodes){
@@ -703,7 +705,7 @@
 									     		$(nodes[i]).attr('data-parsley-required-message', newString);
 									     	}
 
-									     	
+
 									   	}
 									}
 
@@ -822,7 +824,7 @@
 									var po2 = po.slice((po.length-3),(po.length));
 									document.getElementById('entered-po-'+idNo2).innerHTML += (po1 + ' ' + po2);
 								}
-													
+
 							}
 
 							function reEnable(){
@@ -866,7 +868,7 @@
 									else {
 										$('#current-address-'+count).find('input,select,radio').prop('disabled', true);
 										$('#not-current-address-'+count).find('input,select,radio').prop('disabled', true);
-									} //else 
+									} //else
 
 									if ($('#postcode-block-'+count).hasClass('js-hidden')) {
 										$('#address-fields-block-'+count).find('input,select,radio').prop('disabled', false);
@@ -925,7 +927,7 @@
 						</p>
 						<h2 class="heading-small">If you were in HM Armed Forces</h2>
 						<p>
-							If you've been in HM Armed Forces enter your full BFPO (British Forces Post Office) number. 
+							If you've been in HM Armed Forces enter your full BFPO (British Forces Post Office) number.
 						</p>
 						<h2 class="heading-small">If you were homeless</h2>
 						<p>
@@ -934,7 +936,7 @@
 						</p>
 
 						<p>
-							If you lived in temporary accommodation (for example, a hostel) enter that address. 
+							If you lived in temporary accommodation (for example, a hostel) enter that address.
 						</p>
 						<h2 class="heading-small">If you were in a women's refuge or sheltered accommodation</h2>
 						<p>
@@ -948,9 +950,9 @@
 
 
 					</div> <!-- END HELP BLOCK -->
-			    
+
 				</div>
-			    
+
 
 			    <!-- Continue button -->
 			    <div class="form-group">
@@ -989,7 +991,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -1031,7 +1033,7 @@
 			// else disable those fields
 			if ($(this).val() == "Yes") {
 				// remove disabled prop
-				
+
 				correctAddressPanel.find('input,select,radio').prop('disabled',false);
 				newAddressPanel.find('input,select,radio').prop('disabled',true);
 				}
@@ -1039,7 +1041,7 @@
 
 				correctAddressPanel.find('input,select,radio').prop('disabled',true);
 				newAddressPanel.find('input,select,radio').prop('disabled',false);
-				
+
 				// If Postcode finder NOT active, enable address fields
 				// Else enable postcode finder field
 				if ($('#new-manual-toggle-link').hasClass("manual")) {
@@ -1051,7 +1053,7 @@
 					addressPanel.find('input,select,radio').prop('disabled',true);
 				}
 
-				
+
 			}
 		});
 
@@ -1084,7 +1086,7 @@
 			var curSinceDate = String(curSinceYear) + String(curSinceMonth);
 
 
-			// Check if the dates from the previous page satisfy the date constraints 
+			// Check if the dates from the previous page satisfy the date constraints
 			if (curSinceYear <= (yyyy-5)) {
 				if (curSinceYear < (yyyy-5)) {
 					console.log("Current year is over 5 years ago");
@@ -1099,7 +1101,7 @@
 
 
 
-			// Check through other addresses to see if 5 year address history is satisfied 
+			// Check through other addresses to see if 5 year address history is satisfied
 			if (!datesSatisfied) {
 				console.log('Dates not satisfied yet');
 				var othAddsTotal = document.getElementById('other-addresses-total').value;
@@ -1121,7 +1123,7 @@
 							otherYear = document.getElementById('cur-address-since-year-'+oth).value;
 							otherMonth = document.getElementById('cur-address-since-month-'+oth).value;
 						}
-						
+
 						console.log(otherYear);
 
 						if (otherYear <= (yyyy-5)) {
@@ -1143,7 +1145,7 @@
 			}
 
 
-			
+
 			// At least one has to be a current address
 
 			// If dates NOT satisfied, then enable the hidden input to allow validationt to kick in. Else disable to remove validation
@@ -1221,7 +1223,7 @@
 
 
 
-			
+
 			var othAddsTotal = document.getElementById('other-addresses-total').value;
 			othAddsTotal++;
 
@@ -1349,7 +1351,7 @@
 
 
 
-			// If gaps is TRUE (aka gaps exist) enable the validation field 
+			// If gaps is TRUE (aka gaps exist) enable the validation field
 			if (gaps) {
 				$('#gapsCheck').find('input,select,radio').prop('disabled',false);
 			} else {
@@ -1361,5 +1363,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formPlaceBirth.html
+++ b/app/views/formPlaceBirth.html
@@ -3,33 +3,36 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Where were you born?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
-			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
+			{% include 'includes/error_summary.html' %}
+      {# include if this page has validation requirements #}
 
-			<form action="formAddNames" method="post" class="form">
 
-				
+
+      <h1 class="heading-medium">{{ main_question }}</h1>
 			  	<!-- Where were you born? -->
+          <form action="formAddNames" method="post" class="form">
 			    <div id="country-of-birth-form-group" class="form-group">
-			      	<legend class="heading-medium">Where were you born?</legend>
+			      	<legend class="visuallyhidden">{{main_question}}</legend>
 
 
 			      	<label class="form-label" for="country-of-birth">Country</label>
 			      	<div id="country-of-birth-form-group-error-message" class="form-error validation-message"></div>
 			      	<select class="form-control" name="country-of-birth" id="country-of-birth"
-			      			data-parsley-class-handler="#country-of-birth-form-group" 
+			      			data-parsley-class-handler="#country-of-birth-form-group"
           					data-parsley-errors-container="#country-of-birth-form-group-error-message"
           					data-parsley-required="true"
-    						data-parsley-required-message="Enter your country of birth" 
+    						data-parsley-required-message="Enter your country of birth"
     				>
 
-    					
+
 						<option value="Afganistan">Afghanistan</option>
 						<option value="Albania">Albania</option>
 						<option value="Algeria">Algeria</option>
@@ -287,10 +290,10 @@
 			      	<label class="form-label" for="city-of-birth">Town/City</label>
 			      	<div id="city-of-birth-form-group-error-message" class="form-error validation-message"></div>
 			      	<input type="text" class="form-control" name="city-of-birth" id="city-of-birth"
-			      			data-parsley-class-handler="#city-of-birth-form-group" 
+			      			data-parsley-class-handler="#city-of-birth-form-group"
           					data-parsley-errors-container="#city-of-birth-form-group-error-message"
           					data-parsley-required="true"
-    						data-parsley-required-message="Enter your town/city of birth" 
+    						data-parsley-required-message="Enter your town/city of birth"
     				>
 			    </div> <!-- Form group close-->
 
@@ -328,7 +331,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -360,5 +363,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formSendAddress.html
+++ b/app/views/formSendAddress.html
@@ -3,28 +3,29 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question= "Where would you like your certificate to be sent?" %}
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
 		<div class="column-two-thirds">
 
 			{% include 'includes/error_summary.html' %}{# include if this page has validation requirements #}
 
+      <h1 class="heading-medium">{{main_question}}</h1>
+      <p>Your certificate can be sent to your current address, another personal address, or your employer.</p>
 			<form action="formEmail" method="post" class="form">
-
-				
 			  	<!-- Details correct -->
 				<div id="send-details-group" class="form-group">
 					<fieldset>
-						<legend class="heading-medium">Where would you like your certificate to be sent?</legend>
-						<p class="form-hint">Your certificate can be sent to your current address, another personal address, or your employer.</p>
+						<legend class="visuallyhidden">{{main_question}}</legend>
+
 						<div id="send-details-group-error-message" class="form-error validation-message"></div>
-						
+
 					    <label class="block-label" for="correct-radio-1" data-target="current-address">
 							<input id="correct-radio-1" type="radio" name="radio-correct-group" value="Current"
-									data-parsley-class-handler="#send-details-group" 
+									data-parsley-class-handler="#send-details-group"
           							data-parsley-errors-container="#send-details-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Select if you want your certificate to be sent to your current address or another address"
@@ -35,18 +36,18 @@
 						<!-- Expandable panel area  ANOTHER ADDRESS-->
 			    		<div class="panel panel-border-narrow js-hidden" id="current-address">
 			    			<div class="form-group">
-								<p class="form-hint">This is your current address.</p>
-								<span>
+								<p>This is your current address:</p>
+								<p>
 									1 Oxford Road<br>
 									Bristol<br>
 									South Gloucestershire<br>
 									United Kingdom<br>
 									LP1 12D
-								</span>
+								<p>
 							</div>
 			    		</div>
 
-								
+
 						<label class="block-label" data-target="another-address" for="correct-radio-2">
 							<input id="correct-radio-2" type="radio" name="radio-correct-group" value="Another">
 							To another address
@@ -55,7 +56,7 @@
 
 					<!-- Expandable panel area  ANOTHER ADDRESS-->
 			    	<div class="panel panel-border-narrow js-hidden" id="another-address">
-			    		
+
 
 			    	<!-- Postcode block -->
 			    		<div class="form-group" id="postcode-block">
@@ -64,7 +65,7 @@
 								<label class="form-label" for="postcode">Postcode</label>
 								<div id="postcode-block-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="send-postcode" type="text" id="postcode"
-									data-parsley-class-handler="#postcode-block" 
+									data-parsley-class-handler="#postcode-block"
           							data-parsley-errors-container="#postcode-block-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the address"
@@ -80,7 +81,7 @@
 						-->
 
 							<div class="form-group">
-								<label class="form-label">Postcode:</label> 
+								<label class="form-label">Postcode:</label>
 									<div id="entered-po" style="font-weight:bold;"></div>
 									<a href="#/" role="button" onClick="javascript:poLookup();">Change</a>
 
@@ -93,7 +94,7 @@
 									<li>
 										<label>
 											<input disabled type="radio" value="1 Oxford Road, London, United Kingdom" name="send-found-address"
-												data-parsley-class-handler="#po-finder-addresses" 
+												data-parsley-class-handler="#po-finder-addresses"
 			          							data-parsley-errors-container="#po-finder-error-message"
 			          							data-parsley-required="true"
 			    								data-parsley-required-message="Select the address"
@@ -141,7 +142,7 @@
 								<label class="form-label" for="send-recipient">Recipient</label>
 								<div id="recipient-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="send-recipient" type="text" id="send-recipient"
-									data-parsley-class-handler="#recipient-group" 
+									data-parsley-class-handler="#recipient-group"
           							data-parsley-errors-container="#recipient-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the recipient"
@@ -151,7 +152,7 @@
 								<label class="form-label" for="send-address-line-1">Address line 1</label>
 								<div id="address-line-1-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="send-address-line-1" type="text" id="send-address-line-1"
-									data-parsley-class-handler="#address-line-1-group" 
+									data-parsley-class-handler="#address-line-1-group"
           							data-parsley-errors-container="#address-line-1-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the first line of your address"
@@ -165,7 +166,7 @@
 								<label class="form-label" for="send-address-town-city">Town/City</label>
 								<div id="town-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="send-address-town-city" type="text" id="send-address-town-city"
-									data-parsley-class-handler="#town-group" 
+									data-parsley-class-handler="#town-group"
           							data-parsley-errors-container="#town-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the town/city"
@@ -179,7 +180,7 @@
 								<label class="form-label" for="send-address-country">Country</label>
 								<div id="country-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="send-address-country" type="text" id="send-address-country"
-									data-parsley-class-handler="#country-group" 
+									data-parsley-class-handler="#country-group"
           							data-parsley-errors-container="#country-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the country"
@@ -189,7 +190,7 @@
 								<label class="form-label" for="send-address-postcode">Postcode</label>
 								<div id="postcode-group-error-message" class="form-error validation-message"></div>
 								<input disabled class="form-control" name="send-address-postcode" type="text" id="send-address-postcode"
-									data-parsley-class-handler="#postcode-group" 
+									data-parsley-class-handler="#postcode-group"
           							data-parsley-errors-container="#postcode-group-error-message"
           							data-parsley-required="true"
     								data-parsley-required-message="Enter the postcode"
@@ -253,7 +254,7 @@
 								var po2 = po.slice((po.length-3),(po.length));
 								document.getElementById('entered-po').innerHTML += (po1 + ' ' + po2);
 							}
-							
+
 						}
 			    	</script>
 
@@ -265,7 +266,7 @@
 			    <div class="form-group">
 			    	<input type="submit" class="button" value="Save and continue">
 				</div> <!-- Form group close-->
-				
+
 			</form>
 		</div>
 	</div>
@@ -294,7 +295,7 @@
 
 	    var ok = true;
 	    // add custom validations here - set ok to false if any of them fail validation
-	    
+
 	    //ok = ok && checkDiagnosisFutureDate();
 	    //ok = ok && validateDOB();
 
@@ -351,5 +352,3 @@
 </script>
 
 {% endblock %}
-
-

--- a/app/views/formSummary.html
+++ b/app/views/formSummary.html
@@ -3,19 +3,21 @@
 {% block page_title %}
   DBS Prototype
 {% endblock %}
-
+{% set main_question = "Confirm your details" %}
 {% block content %}
 
 <main id="content" role="main">
+
+{% include 'includes/phase_banner_alpha.html' %}
 	<div class="grid-row">
-		<div class="column-two-thirds">			
-			
+		<div class="column-two-thirds">
+
 			<form action="formDeclaration" method="post" class="form">
 
 
-				<div class="form-group">
-			    	<h3 class="heading-medium">Confirm your details before continuing</h3>
-			    </div>
+
+			    	<h1 class="heading-large">{{ main_question}}</h3>
+
 			    <div class="form-group">
 
 				    <table>
@@ -23,20 +25,20 @@
 					    	<!-- Name -->
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Name</h2>
-					    			<div>John Scott Smith</div>
+					    			<span class="bold-small">Name</span><br/>
+                      John Scott Smith
 					    		</td>
-					    		<td class="editButton">
-					    		
+					    		<td>
+
 					    		</td>
 					    	</tr>
 					    	<!-- Date of Birth -->
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Date of birth</h2>
-					    			<div>01/01/1960</div>
+					    			<span class="bold-small">Date of birth</span><br/>
+					    			01/01/1960
 					    		</td>
-					    		<td class="editButton">
+					    		<td>
 
 					    		</td>
 					    	</tr>
@@ -44,25 +46,25 @@
 					    	<!-- Gender -->
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Sex</h2>
-					    			<div>{{ formdata["radio-gender-group"] }}</div>
-					    			
+					    			<span class="bold-small">Sex</span><br/>
+					    			{{ formdata["radio-gender-group"] }}
+
 					    		</td>
-					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    		<td >
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
 
 					    	<!-- Place of birth -->
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Place of birth</h2>
-					    			<div>{{ formdata["country-of-birth"] }}</div>
-					    			<div>{{ formdata["city-of-birth"] }}</div>
-					    			
+					    			<span class="bold-small">Place of birth</span><br/>
+					    			{{ formdata["country-of-birth"] }}
+					    			{{ formdata["city-of-birth"] }}
+
 					    		</td>
-					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    		<td>
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
 
@@ -70,14 +72,14 @@
 					    	{% if formdata["other-family-name"] %}
 						    	<tr>
 						    		<td>
-						    			<h2 class="text-secondary">Other name</h2>
-						    			<div>{{ formdata["other-given-names"] }} {{ formdata["other-family-name"] }}</div>
-						    			<h2 class="text-secondary">Date from</h2>
-						    			<div>{{ formdata["other-name-from-month"] }}/{{ formdata["other-name-from-year"] }}</div>
-						    			</div>
+						    			<span class="bold-small">Other name</span><br/>
+						    			{{ formdata["other-given-names"] }} {{ formdata["other-family-name"] }}<br/><br/>
+						    			<span class="bold-small">Date from</span><br/>
+						    			{{ formdata["other-name-from-month"] }}/{{ formdata["other-name-from-year"] }}
+
 						    		</td>
 						    		<td class="editButton">
-						    			<a class="button button-secondary">Edit</a>
+						    			<a href="#">Edit</a>
 						    		</td>
 						    	</tr>
 						    {% endif %}
@@ -86,38 +88,38 @@
 						    	{% if formdata["other-family-name-"+n] %}
 						    	<tr>
 						    		<td>
-						    			<h2 class="text-secondary">Other name {{n}}</h2>
-						    			<div>{{ formdata["other-given-names-"+n] }} {{ formdata["other-family-name-"+n] }}</div>
-						    			<h2 class="text-secondary">Date from</h2>
-						    			<div>{{ formdata["other-name-from-month-"+n] }}/{{ formdata["other-name-from-year-"+n] }}</div>
-						    			
+						    			<span class="bold-small">Other name {{n}}</span><br/>
+						    			{{ formdata["other-given-names-"+n] }} {{ formdata["other-family-name-"+n] }}
+						    			<span class="bold-small">Date from</span><br/>
+						    			{{ formdata["other-name-from-month-"+n] }}/{{ formdata["other-name-from-year-"+n] }}
+
 						    		</td>
 						    		<td class="editButton">
-						    			<a class="button button-secondary">Edit</a>
+						    			<a href="#">Edit</a>
 						    		</td>
 						    	</tr>
 						    	{% endif %}
 
 						    {% endfor %}
 
-					    	
+
 
 					    	<!-- Current address -->
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Current address</h2>
-					    			<div>
+					    			<span class="bold-small">Current address</span>
+					    			<p>
 					    				1 Oxford Road<br>
 										Bristol<br>
 										South Gloucestershire<br>
 										United Kingdom<br>
 										LP1 12D
-					    			</div>
-					    			<h2 class="text-secondary">At address since</h2>
-					    			<div>{{ formdata["correct-address-since-month"] }}/{{ formdata["correct-address-since-year"] }}</div>
+                  </p>
+					    			<span class="bold-small">At address since</span><br/>
+					    			{{ formdata["correct-address-since-month"] }}/{{ formdata["correct-address-since-year"] }}
 					    		</td>
 					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
 
@@ -126,57 +128,57 @@
 					    		{% if formdata["postcode-"+i] %}
 						    		<tr>
 							    		<td>
-							    			<h2 class="text-secondary">Other address {{i}}</h2>
-							    			<div>{{ formdata["postcode-"+i] }}</div>
-							    			<h2 class="text-secondary">At address since</h2>
-							    			<div>{{ formdata["cur-address-since-month-"+i] }}{{ formdata["nc-address-since-month-"+i] }}/{{ formdata["cur-address-since-year-"+i] }}{{ formdata["nc-address-since-year-"+i] }}</div>
-							    			{% if formdata["nc-address-to-month-"+i] %}
-							    				<h2 class="text-secondary">At address to</h2>
-							    				<div>{{ formdata["nc-address-to-month-"+i] }}/{{ formdata["nc-address-to-year-"+i] }}</div>
+							    			<span class="bold-small">Other address {{i}}</span><br/>
+							    			{{ formdata["postcode-"+i] }}<br/><br/>
+							    			<span class="bold-small">At address since</span><br/>
+							    			{{ formdata["cur-address-since-month-"+i] }}{{ formdata["nc-address-since-month-"+i] }}/{{ formdata["cur-address-since-year-"+i] }}{{ formdata["nc-address-since-year-"+i] }}<br/>
+							    			{% if formdata["nc-address-to-month-"+i] %}<br/><br/>
+							    			<span class="bold-small">At address to</span><br/>
+							    		  {{ formdata["nc-address-to-month-"+i] }}/{{ formdata["nc-address-to-year-"+i] }}<br/>
 							    			{% endif %}
 							    		</td>
 							    		<td class="editButton">
-							    			<a class="button button-secondary">Edit</a>
+							    			<a href="#">Edit</a>
 							    		</td>
 							    	</tr>
 
 						    	{% elif formdata["address-line-1-"+i] %}
 							    	<tr>
 							    		<td>
-							    			<h2 class="text-secondary">Other address {{i}}</h2>
-							    			<div>{{ formdata["address-line-1-"+i] }}</div>
-							    			<div>{{ formdata["address-line-2-"+i] }}</div>
-							    			<div>{{ formdata["address-town-city-"+i] }}</div>
-							    			<div>{{ formdata["address-county-"+i] }}</div>
-							    			<div>{{ formdata["address-country-"+i] }}</div>
-							    			<div>{{ formdata["address-postcode-"+i] }}</div>
-							    			<h2 class="text-secondary">At address since</h2>
-							    			<div>{{ formdata["cur-address-since-month-"+i] }}{{ formdata["nc-address-since-month-"+i] }}/{{ formdata["cur-address-since-year-"+i] }}{{ formdata["nc-address-since-year-"+i] }}</div>
-							    			{% if formdata["nc-address-to-month-"+i] %}
-							    				<h2 class="text-secondary">At address to</h2>
-							    				<div>{{ formdata["nc-address-to-month-"+i] }}/{{ formdata["nc-address-to-year-"+i] }}</div>
+							    			<span class="bold-small">Other address {{i}}</span><br/>
+							    			{{ formdata["address-line-1-"+i] }}<br/>
+							    			{{ formdata["address-line-2-"+i] }}<br/>
+							    			{{ formdata["address-town-city-"+i] }}<br/>
+							    			{{ formdata["address-county-"+i] }}<br/>
+							    			{{ formdata["address-country-"+i] }}<br/>
+							    			{{ formdata["address-postcode-"+i] }}<br/><br/>
+							    			<span class="bold-small">At address since</span><br/>
+							    			{{ formdata["cur-address-since-month-"+i] }}{{ formdata["nc-address-since-month-"+i] }}/{{ formdata["cur-address-since-year-"+i] }}{{ formdata["nc-address-since-year-"+i] }}<br/>
+							    			{% if formdata["nc-address-to-month-"+i] %}<br/><br/>
+							    				<span class="bold-small">At address to</span><br/>
+							    				{{ formdata["nc-address-to-month-"+i] }}/{{ formdata["nc-address-to-year-"+i] }}
 							    			{% endif %}
 							    		</td>
 							    		<td class="editButton">
-							    			<a class="button button-secondary">Edit</a>
+							    			<a href="#">Edit</a>
 							    		</td>
 							    	</tr>
 					    		{% endif %}
 					    	{% endfor %}
 
-					    	
+
 
 
 					    	<!-- National Insurance number -->
 					    	{% if formdata["ni-number-input"] %}
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">National Insurance number</h2>
-					    			<div>{{ formdata["ni-number-input"] }}</div>
-					    			
+					    			<span class="bold-small">National Insurance number</span><br/>
+					    			{{ formdata["ni-number-input"] }}
+
 					    		</td>
 					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
 					    	{% endif %}
@@ -185,11 +187,11 @@
 					    	{% if formdata["driving-licence-number-input"] %}
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Driving licence number</h2>
-					    			<div>{{ formdata["driving-licence-number-input"] }}</div>
+					    			<span class="bold-small">Driving licence number</span><br/>
+					    			{{ formdata["driving-licence-number-input"] }}
 					    		</td>
 					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
 					    	{% endif %}
@@ -198,11 +200,11 @@
 					    	{% if formdata["passport-number-input"] %}
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Passport number</h2>
-					    			<div>{{ formdata["passport-number-input"] }}</div>
+					    			<span class="bold-small">Passport number</span><br/>
+					    			{{ formdata["passport-number-input"] }}
 					    		</td>
 					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
 					    	{% endif %}
@@ -210,46 +212,46 @@
 					    	<!-- Previous convictions -->
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Unspent Convictions</h2>
+					    			<span class="bold-small">Unspent Convictions</span><br/>
 					    			{% if formdata["radio-convictions-group"] == 'Yes' %}
-					    				<div>I do have unspent convictions</div>
+					    				I do have unspent convictions
 					    			{% else %}
-					    				<div>I do not have unspent convictions</div>
+					    				I do not have unspent convictions
 					    			{% endif %}
 					    		</td>
 					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
-							
+
 
 					    	<!-- Send address -->
 					    	{% if formdata["send-postcode"] or formdata["send-address-line-1"] %}
 							    <tr>
 							    	<td>
-							    		<h2 class="text-secondary">Send certificate to</h2>
-							    		<div>{{ formdata["send-postcode"] }}</div>
-							    		<div>{{ formdata["send-recipient"] }}</div>
-							    		<div>{{ formdata["send-address-line-1"] }}</div>
-							    		<div>{{ formdata["send-address-line-2"] }}</div>
-							    		<div>{{ formdata["send-address-town-city"] }}</div>
-							    		<div>{{ formdata["send-address-county"] }}</div>
-							    		<div>{{ formdata["send-address-country"] }}</div>
-							    		<div>{{ formdata["send-address-postcode"] }}</div>
+							    		<span class="bold-small">Send certificate to</span><br/>
+							    		{{ formdata["send-postcode"] }}<br/>
+							    		{{ formdata["send-recipient"] }}<br/>
+							    		{{ formdata["send-address-line-1"] }}<br/>
+							    		{{ formdata["send-address-line-2"] }}<br/>
+							    		{{ formdata["send-address-town-city"] }}<br/>
+							    		{{ formdata["send-address-county"] }}<br/>
+							    		{{ formdata["send-address-country"] }}<br/>
+							    		{{ formdata["send-address-postcode"] }}
 							    	</td>
 							    	<td class="editButton">
-							    		<a class="button button-secondary">Edit</a>
+							    		<a href="#">Edit</a>
 							    	</td>
 							    </tr>
 
 							{% else %}
 								<tr>
 							    	<td>
-							    		<h2 class="text-secondary">Send certificate to</h2>
-							    		<div>Send to my current address</div>
+							    		<span class="bold-small">Send certificate to</span><br/>
+							    		Send to my current address
 							    	</td>
 							    	<td class="editButton">
-							    		<a class="button button-secondary">Edit</a>
+							    		<a href="#">Edit</a>
 							    	</td>
 							    </tr>
 					    	{% endif %}
@@ -259,12 +261,12 @@
 					    	<!-- Email address -->
 					    	<tr>
 					    		<td>
-					    			<h2 class="text-secondary">Email address</h2>
-					    			<div>{{ formdata["email-address"] }}</div>
-					    			
+					    			<span class="bold-small">Email address</span><br/>
+					    			{{ formdata["email-address"] }}
+
 					    		</td>
 					    		<td class="editButton">
-					    			<a class="button button-secondary">Edit</a>
+					    			<a href="#">Edit</a>
 					    		</td>
 					    	</tr>
 
@@ -289,5 +291,3 @@
 </main>
 
 {% endblock %}
-
-

--- a/app/views/formVerifyPass.html
+++ b/app/views/formVerifyPass.html
@@ -7,6 +7,7 @@
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
   <div class="grid-row">
   	<div class="column-two-thirds">
     	<h1 class="heading-large">You have passed Verify</h1>
@@ -27,5 +28,3 @@
 </main>
 
 {% endblock %}
-
-

--- a/app/views/formVerifying.html
+++ b/app/views/formVerifying.html
@@ -7,6 +7,7 @@
 {% block content %}
 
 <main id="content" role="main">
+  {% include 'includes/phase_banner_alpha.html' %}
   <div class="grid-row">
   	<div class="column-two-thirds">
 
@@ -15,11 +16,11 @@
     	<h1 class="heading-large">Verifying your identity</h1>
 
         <p>You need to verify your identity to get a basic criminal record check.</p>
-        
+
         <p>You can do this online now using GOV.UK Verify.</p>
 
         <p>It takes about 10 minutes to verify your identity the first time you use GOV.UK Verify, and a couple of minutes any time after that. </p>
-        
+
 
         <div class="form-group">
             <a role="button" id="helpBlock" href="#/" onClick="javascript:toggleHelp();">
@@ -37,13 +38,13 @@
                 </p><p>
                     It’s fast and simple because you can do it all online, without going to prove your identity in person, or waiting for something in the post.
                 </p><p>
-                    <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify">Read more about GOV.UK Verify.</a> 
+                    <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify">Read more about GOV.UK Verify.</a>
                 </p>
-                        
+
 
 
             </div> <!-- END HELP BLOCK -->
-                
+
         </div>
 
 
@@ -63,11 +64,11 @@
                     <div id="verify-agree-group-error-message" class="form-error validation-message"></div>
                     <label class="block-label" for="verify-agree">
                         <input id="verify-agree" type="checkbox" name="verify-agree" value="Agree"
-                            data-parsley-class-handler="#verify-agree-group" 
+                            data-parsley-class-handler="#verify-agree-group"
                                     data-parsley-errors-container="#verify-agree-group-error-message"
                                     data-parsley-required="true"
                                     data-parsley-required-message="You must agree to share your details from GOV.UK Verify">
-                        I agree to the Disclosure and Barring Service using my name, address and date of birth provided by GOV.UK Verify 
+                        I agree to the Disclosure and Barring Service using my name, address and date of birth provided by GOV.UK Verify
                     </label>
                 </div>
                 <a class="button button-start" href="https://govuk-verify.herokuapp.com/intro?requestId=dbs-basic-application">Continue to GOV.UK Verify</a>
@@ -88,7 +89,7 @@
 
         <div>
 
-        	
+
             <div class="">
                 <a href="https://govuk-verify.herokuapp.com/intro?requestId=dbs-basic-application&verify=false">TEST fail verify</a><br>
                 <a href="formFirstPage.html">TEST skip Verify</a>
@@ -121,7 +122,7 @@
 
         var ok = true;
         // add custom validations here - set ok to false if any of them fail validation
-        
+
         //ok = ok && checkDiagnosisFutureDate();
         //ok = ok && validateDOB();
 
@@ -170,5 +171,3 @@
 
 
 {% endblock %}
-
-

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -286,10 +286,10 @@ td {
 
 main {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -302,10 +302,10 @@ main {
 
 .font-xxlarge {
   font-family: "nta", Arial, sans-serif;
-  font-size: 53px;
-  line-height: 1.0377358491;
   font-weight: 400;
   text-transform: none;
+  font-size: 53px;
+  line-height: 1.0377358491;
 }
 
 @media (min-width: 641px) {
@@ -317,10 +317,10 @@ main {
 
 .font-xlarge {
   font-family: "nta", Arial, sans-serif;
-  font-size: 32px;
-  line-height: 1.09375;
   font-weight: 400;
   text-transform: none;
+  font-size: 32px;
+  line-height: 1.09375;
 }
 
 @media (min-width: 641px) {
@@ -332,10 +332,10 @@ main {
 
 .font-large {
   font-family: "nta", Arial, sans-serif;
-  font-size: 24px;
-  line-height: 1.0416666667;
   font-weight: 400;
   text-transform: none;
+  font-size: 24px;
+  line-height: 1.0416666667;
 }
 
 @media (min-width: 641px) {
@@ -347,10 +347,10 @@ main {
 
 .font-medium {
   font-family: "nta", Arial, sans-serif;
-  font-size: 18px;
-  line-height: 1.2;
   font-weight: 400;
   text-transform: none;
+  font-size: 18px;
+  line-height: 1.2;
 }
 
 @media (min-width: 641px) {
@@ -362,10 +362,10 @@ main {
 
 .font-small {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
 }
 
 @media (min-width: 641px) {
@@ -377,10 +377,10 @@ main {
 
 .font-xsmall {
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 400;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
 }
 
 @media (min-width: 641px) {
@@ -392,10 +392,10 @@ main {
 
 .bold-xxlarge {
   font-family: "nta", Arial, sans-serif;
-  font-size: 53px;
-  line-height: 1.0377358491;
   font-weight: 700;
   text-transform: none;
+  font-size: 53px;
+  line-height: 1.0377358491;
 }
 
 @media (min-width: 641px) {
@@ -407,10 +407,10 @@ main {
 
 .bold-xlarge {
   font-family: "nta", Arial, sans-serif;
-  font-size: 32px;
-  line-height: 1.09375;
   font-weight: 700;
   text-transform: none;
+  font-size: 32px;
+  line-height: 1.09375;
 }
 
 @media (min-width: 641px) {
@@ -422,10 +422,10 @@ main {
 
 .bold-large {
   font-family: "nta", Arial, sans-serif;
-  font-size: 24px;
-  line-height: 1.0416666667;
   font-weight: 700;
   text-transform: none;
+  font-size: 24px;
+  line-height: 1.0416666667;
 }
 
 @media (min-width: 641px) {
@@ -437,10 +437,10 @@ main {
 
 .bold-medium {
   font-family: "nta", Arial, sans-serif;
-  font-size: 18px;
-  line-height: 1.2;
   font-weight: 700;
   text-transform: none;
+  font-size: 18px;
+  line-height: 1.2;
 }
 
 @media (min-width: 641px) {
@@ -452,10 +452,10 @@ main {
 
 .bold-small {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 700;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
 }
 
 @media (min-width: 641px) {
@@ -467,10 +467,10 @@ main {
 
 .bold-xsmall {
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 700;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
 }
 
 @media (min-width: 641px) {
@@ -482,10 +482,10 @@ main {
 
 .heading-xlarge {
   font-family: "nta", Arial, sans-serif;
-  font-size: 32px;
-  line-height: 1.09375;
   font-weight: 700;
   text-transform: none;
+  font-size: 32px;
+  line-height: 1.09375;
   margin-top: 0.46875em;
   margin-bottom: 0.9375em;
 }
@@ -506,10 +506,10 @@ main {
 
 .heading-xlarge .heading-secondary {
   font-family: "nta", Arial, sans-serif;
-  font-size: 20px;
-  line-height: 1.1111111111;
   font-weight: 400;
   text-transform: none;
+  font-size: 20px;
+  line-height: 1.1111111111;
   display: block;
   padding-top: 8px;
   padding-bottom: 7px;
@@ -533,10 +533,10 @@ main {
 
 .heading-large {
   font-family: "nta", Arial, sans-serif;
-  font-size: 24px;
-  line-height: 1.0416666667;
   font-weight: 700;
   text-transform: none;
+  font-size: 24px;
+  line-height: 1.0416666667;
   margin-top: 1.0416666667em;
   margin-bottom: 0.4166666667em;
 }
@@ -557,10 +557,10 @@ main {
 
 .heading-large .heading-secondary {
   font-family: "nta", Arial, sans-serif;
-  font-size: 18px;
-  line-height: 1.2;
   font-weight: 400;
   text-transform: none;
+  font-size: 18px;
+  line-height: 1.2;
   display: block;
   padding-top: 9px;
   padding-bottom: 6px;
@@ -584,10 +584,10 @@ main {
 
 .heading-medium {
   font-family: "nta", Arial, sans-serif;
-  font-size: 18px;
-  line-height: 1.2;
   font-weight: 700;
   text-transform: none;
+  font-size: 18px;
+  line-height: 1.2;
   margin-top: 1.25em;
   margin-bottom: 0.5em;
 }
@@ -608,10 +608,10 @@ main {
 
 .heading-small {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 700;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   margin-top: 0.625em;
   margin-bottom: 0.3125em;
 }
@@ -643,10 +643,10 @@ p {
 
 .lede {
   font-family: "nta", Arial, sans-serif;
-  font-size: 18px;
-  line-height: 1.2;
   font-weight: 400;
   text-transform: none;
+  font-size: 18px;
+  line-height: 1.2;
 }
 
 @media (min-width: 641px) {
@@ -686,10 +686,10 @@ p {
   display: inline-block;
   position: relative;
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 400;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
   margin-top: 15px;
   margin-bottom: 15px;
   padding-left: 14px;
@@ -885,10 +885,10 @@ hr {
 .button-start,
 .button-get-started {
   font-family: "nta", Arial, sans-serif;
-  font-size: 18px;
-  line-height: 1.2;
   font-weight: 700;
   text-transform: none;
+  font-size: 18px;
+  line-height: 1.2;
   background-image: url("/public/images/icon-pointer.png");
   background-repeat: no-repeat;
   background-position: 100% 50%;
@@ -1263,10 +1263,10 @@ table {
 table th,
 table td {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   padding: 0.6315789474em 1.0526315789em 0.4736842105em 0;
   text-align: left;
   color: #0b0c0c;
@@ -1291,10 +1291,10 @@ table th.numeric {
 
 table td.numeric {
   font-family: "ntatabularnumbers", "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 400;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
   text-align: right;
 }
 
@@ -1305,16 +1305,12 @@ table td.numeric {
   }
 }
 
-table td.editButton {
-  text-align: right;
-}
-
 .table-font-xsmall th {
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 700;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
 }
 
 @media (min-width: 641px) {
@@ -1326,10 +1322,10 @@ table td.editButton {
 
 .table-font-xsmall td {
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 400;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
 }
 
 @media (min-width: 641px) {
@@ -1416,7 +1412,6 @@ textarea {
   box-sizing: border-box;
   float: left;
   width: 100%;
-  padding-top: 1px;
   margin-bottom: 15px;
 }
 
@@ -1448,10 +1443,10 @@ textarea {
 
 .form-label {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
 }
 
 @media (min-width: 641px) {
@@ -1463,10 +1458,10 @@ textarea {
 
 .form-label-bold {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 700;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
 }
 
 @media (min-width: 641px) {
@@ -1502,10 +1497,10 @@ legend .form-label-bold {
 
 .form-hint {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   display: block;
   color: #6f777b;
   font-weight: normal;
@@ -1524,10 +1519,10 @@ legend .form-label-bold {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   width: 100%;
   padding: 4px;
   background-color: #fff;
@@ -1745,10 +1740,10 @@ input[type=number] {
 
 .error-message {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   display: block;
   clear: both;
   margin: 0;
@@ -1813,10 +1808,10 @@ input[type=number] {
 
 .breadcrumbs li {
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 400;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
   float: left;
   background-image: url("/public/images/separator.png");
   background-position: 0% 50%;
@@ -1867,10 +1862,10 @@ input[type=number] {
   margin: 0;
   color: #000;
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 400;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
 }
 
 @media (min-width: 641px) {
@@ -1886,10 +1881,10 @@ input[type=number] {
   margin: 0 8px 0 0;
   padding: 2px 5px 0;
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 700;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
   text-transform: uppercase;
   letter-spacing: 1px;
   text-decoration: none;
@@ -1925,10 +1920,10 @@ input[type=number] {
   margin: 0;
   color: #000;
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 400;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
 }
 
 @media (min-width: 641px) {
@@ -1944,10 +1939,10 @@ input[type=number] {
   margin: 0 8px 0 0;
   padding: 2px 5px 0;
   font-family: "nta", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.1428571429;
   font-weight: 700;
   text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
   text-transform: uppercase;
   letter-spacing: 1px;
   text-decoration: none;
@@ -1984,10 +1979,10 @@ input[type=number] {
 
 .check-your-answers td {
   font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   vertical-align: top;
 }
 
@@ -2050,10 +2045,10 @@ input[type=number] {
 
 .form-error {
   font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
   font-weight: 400;
   text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
   font-weight: bold;
   color: #b10e1e;
 }


### PR DESCRIPTION
- Added alpha banner to all in-service screens
- Removed form-hint class from help text not at field level
- Added H1s for all questions and changed legend to visually hidden
class
- Stored heading as nunjucks variable and replayed in H1 and legend for
all screens
- Tidied up styling on summary screen, including replacing green button
‘edit’ links to standard ‘edit’ blue links